### PR TITLE
Fix restarting app issue

### DIFF
--- a/components/shared/modal/ErrorModal.js
+++ b/components/shared/modal/ErrorModal.js
@@ -1,10 +1,9 @@
 import React from 'react';
+import { Updates } from 'expo';
 import { TouchableOpacity, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import $t from 'i18n';
-
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './baseModal';
-import NavigationService from '../../../services/NavigationService';
 
 const ErrorModal = ({ isVisible, closeModal }) => {
   return (
@@ -19,7 +18,12 @@ const ErrorModal = ({ isVisible, closeModal }) => {
         <TouchableOpacity onPress={closeModal}>
           <Text>{$t('error.cancel')}</Text>
         </TouchableOpacity>
-        <TouchableOpacity onPress={() => NavigationService.navigate('AuthLoading')}>
+        <TouchableOpacity
+          onPress={() => {
+            closeModal();
+            Updates.reload();
+          }}
+        >
           <Text>{$t('error.restart')}</Text>
         </TouchableOpacity>
       </ModalFooter>

--- a/components/shared/modal/ErrorModal.js
+++ b/components/shared/modal/ErrorModal.js
@@ -6,6 +6,11 @@ import $t from 'i18n';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './baseModal';
 
 const ErrorModal = ({ isVisible, closeModal }) => {
+  const _restartApp = () => {
+    closeModal();
+    Updates.reload();
+  };
+
   return (
     <Modal isVisible={isVisible} closeModal={closeModal}>
       <ModalHeader>
@@ -18,12 +23,7 @@ const ErrorModal = ({ isVisible, closeModal }) => {
         <TouchableOpacity onPress={closeModal}>
           <Text>{$t('error.cancel')}</Text>
         </TouchableOpacity>
-        <TouchableOpacity
-          onPress={() => {
-            closeModal();
-            Updates.reload();
-          }}
-        >
+        <TouchableOpacity onPress={_restartApp}>
           <Text>{$t('error.restart')}</Text>
         </TouchableOpacity>
       </ModalFooter>


### PR DESCRIPTION
Currently, when global error happen, by clicking `restart` only navigate to `AuthLoading` stack but it doesn't actually restart the app. To fix that, added expo build-in method to restart the app. 