### PR TITLE
Fixed babel issue when building application

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,22 +5,22 @@ module.exports = function bpe(api) {
     'module:metro-react-native-babel-preset',
     'module:react-native-dotenv'
   ];
-  const plugins = [];
+
+  const moduleResolver = [
+    'module-resolver',
+    {
+      root: './',
+      alias: {
+        i18n: './i18n'
+      }
+    }
+  ];
+
+  const plugins = [moduleResolver];
 
   const envDevelopment = {
     presets: presets,
-    plugins: [
-      '@babel/transform-react-jsx-source',
-      [
-        'module-resolver',
-        {
-          root: './',
-          alias: {
-            i18n: './i18n'
-          }
-        }
-      ]
-    ]
+    plugins: ['@babel/transform-react-jsx-source', moduleResolver]
   };
 
   if (api.env(['development', 'test'])) {


### PR DESCRIPTION
When building application it would throw error for `i18n` imports. The problem was the module resolver we used in babel was set to work only in dev env, I've added it so that it uses the same one for prod as well. 